### PR TITLE
removed redundant sign and register buttons

### DIFF
--- a/Client/src/layouts/tabsLayout.vue
+++ b/Client/src/layouts/tabsLayout.vue
@@ -10,23 +10,6 @@
           PantryPal
         </q-toolbar-title>
 
-        <div class="q-gutter-sm">
-          <q-btn
-            v-if="!isLoggedIn"
-            color="secondary"
-            label="Sign In"
-            to="signin"
-             >
-          </q-btn>
-          <q-btn
-            v-if="!isLoggedIn"
-            color="secondary"
-            label="Register"
-            to="register"
-             >
-          </q-btn>
-        </div>
-
         <div>
           <q-btn
           data-cy="user-btn"


### PR DESCRIPTION
With our layout the sign in and register buttons in the tool bar are not needed. Just removed them. The profile button will still appear after user log in.