### PR TITLE
donator contact info and street address

### DIFF
--- a/Client/src/pages/account.vue
+++ b/Client/src/pages/account.vue
@@ -141,6 +141,9 @@
           <br/>
           <div class="text-subtitle2">{{ pantry_item.pickup_streetaddress }}</div>
           <div class="text-subtitle2">{{ pantry_item.pickup_city }} , {{ pantry_item.pickup_state.value }} {{ pantry_item.pickup_zip }}</div>
+          <div class="text-subtitle2" v-if="userInfo.email != pantry_item.contact_email && pantry_item.user_email != userInfo.email">{{ pantry_item.contact_name }}</div>
+          <div class="text-subtitle2" v-if="userInfo.email != pantry_item.contact_email && pantry_item.user_email != userInfo.email">{{ pantry_item.contact_email }}</div>
+          <div class="text-subtitle2" v-if="userInfo.email != pantry_item.contact_email && pantry_item.user_email != userInfo.email">{{ pantry_item.contact_phone }}</div>
         </q-card-section>
 
         <div class="absolute-bottom">


### PR DESCRIPTION
Fixed a bug where street address was not showing up on pantry item cards on account page.
Added contact information on pantry items on account page for donatees to reach out to donator contact.